### PR TITLE
Add Langevin dynamics simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New features
+
+- System:
+  - Added built-in `friction_attribute` for Langevin dynamics simulation. Also
+    added `system::view_frictions()` etc. for quick access.
+
 ### Bug fixes
 
 - Fixed `system` copy constructor and copy assignment operator. Now, you can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - System:
   - Added built-in `friction_attribute` for Langevin dynamics simulation. Also
     added `system::view_frictions()` etc. for quick access.
+- Simulation:
+  - Added `simulate_langevin_dynamics()`: A function that simulates Langevin
+    dynamics of a system.
 
 ### Bug fixes
 

--- a/include/md.hpp
+++ b/include/md.hpp
@@ -43,6 +43,7 @@
 
 // Simulations
 #include "md/simulation/brownian_dynamics.hpp"
+#include "md/simulation/langevin_dynamics.hpp"
 #include "md/simulation/newtonian_dynamics.hpp"
 
 // Misc.

--- a/include/md/simulation/langevin_dynamics.hpp
+++ b/include/md/simulation/langevin_dynamics.hpp
@@ -1,0 +1,101 @@
+// Copyright snsinfu 2020.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef MD_SIMULATION_LANGEVIN_DYMNAMICS_HPP
+#define MD_SIMULATION_LANGEVIN_DYMNAMICS_HPP
+
+// This module provides a function for simulating Langevin dynamics.
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "../basic_types.hpp"
+#include "../system.hpp"
+
+
+namespace md
+{
+    // Parameters for Langevin dynamics simulation.
+    struct langevin_dynamics_config
+    {
+        // Temperature of the environment in the unit of (thermal) energy. It
+        // can be zero.
+        md::scalar temperature = 1;
+
+        // Time discretization step.
+        md::scalar timestep = 1;
+
+        // Number of steps to simulate.
+        md::step steps = 1;
+
+        // Seed for pseudo-random number generator.
+        std::uint64_t seed = 0;
+
+        // Optional callback function called after each step.
+        std::function<void(md::step)> callback = {};
+    };
+
+    // simulate_langevin_dynamics simulates Langevin dynamics of the system.
+    // It uses mass, friction, position and velocity particle attributes.
+    inline void simulate_langevin_dynamics(
+        md::system& system,
+        md::langevin_dynamics_config config
+    )
+    {
+        md::array_view<md::scalar const> masses = system.view_masses();
+        md::array_view<md::scalar const> frictions = system.view_frictions();
+        md::array_view<md::point> positions = system.view_positions();
+        md::array_view<md::vector> velocities = system.view_velocities();
+
+        md::scalar const temperature = config.temperature;
+        md::scalar const timestep = config.timestep;
+        md::index const particles = system.particle_count();
+
+        std::vector<md::vector> forces(particles);
+        md::random_engine random(config.seed);
+        md::normal_distribution<md::scalar> normal;
+
+        // BAOAB scheme.
+
+        system.compute_force(forces);
+
+        for (md::step step_ctr = 1; step_ctr <= config.steps; step_ctr++) {
+            for (md::index i = 0; i < particles; i++) {
+                md::scalar const damping = std::exp(-frictions[i] * timestep);
+                md::scalar const agitation = 1 - damping * damping;
+                md::scalar const sigma = std::sqrt(temperature * agitation / masses[i]);
+                md::vector const normal_vector = {
+                    normal(random), normal(random), normal(random)
+                };
+
+                // B step
+                velocities[i] += 0.5 * timestep / masses[i] * forces[i];
+
+                // A step
+                positions[i] += 0.5 * timestep * velocities[i];
+
+                // O step
+                velocities[i] *= damping;
+                velocities[i] += sigma * normal_vector;
+
+                // A step
+                positions[i] += 0.5 * timestep * velocities[i];
+            }
+
+            system.compute_force(forces);
+
+            for (md::index i = 0; i < particles; i++) {
+                // B step
+                velocities[i] += 0.5 * timestep / masses[i] * forces[i];
+            }
+
+            if (config.callback) {
+                config.callback(step_ctr);
+            }
+        }
+    }
+}
+
+#endif

--- a/include/md/system.hpp
+++ b/include/md/system.hpp
@@ -31,6 +31,13 @@ namespace md
         return 1;
     }
 
+    // friction_attribute is an attribute key for particle friction coefficient.
+    // This is used in langevin dynamics simulations. The default value is 1.
+    inline constexpr md::scalar friction_attribute(struct tag_friction_attribute*)
+    {
+        return 1;
+    }
+
     // mobility_attribute is an attribute key for particle mobility. This is
     // used in brownian dynamics simulations. The default value is 1.
     inline constexpr md::scalar mobility_attribute(struct tag_mobility_attribute*)
@@ -58,6 +65,7 @@ namespace md
     {
         md::scalar mass = md::default_value(md::mass_attribute);
         md::scalar mobility = md::default_value(md::mobility_attribute);
+        md::scalar friction = md::default_value(md::friction_attribute);
         md::point position = md::default_value(md::position_attribute);
         md::vector velocity = md::default_value(md::velocity_attribute);
     };
@@ -69,6 +77,7 @@ namespace md
         system()
         {
             add_attribute(md::mass_attribute);
+            add_attribute(md::friction_attribute);
             add_attribute(md::mobility_attribute);
             add_attribute(md::position_attribute);
             add_attribute(md::velocity_attribute);
@@ -82,6 +91,7 @@ namespace md
             attributes_.resize(idx + 1);
 
             view_masses()[idx] = data.mass;
+            view_frictions()[idx] = data.friction;
             view_mobilities()[idx] = data.mobility;
             view_positions()[idx] = data.position;
             view_velocities()[idx] = data.velocity;
@@ -141,6 +151,17 @@ namespace md
         md::array_view<md::scalar const> view_masses() const noexcept
         {
             return attributes_.view(md::mass_attribute);
+        }
+
+        // view_frictions returns a view of built-in friction attributes.
+        md::array_view<md::scalar> view_frictions() noexcept
+        {
+            return attributes_.view(md::friction_attribute);
+        }
+
+        md::array_view<md::scalar const> view_frictions() const noexcept
+        {
+            return attributes_.view(md::friction_attribute);
         }
 
         // view_mobilities returns a view of built-in mobility attributes.
@@ -259,6 +280,7 @@ namespace md
         : system{system}
         , index{idx}
         , mass{system.view_masses()[idx]}
+        , friction{system.view_frictions()[idx]}
         , mobility{system.view_mobilities()[idx]}
         , position{system.view_positions()[idx]}
         , velocity{system.view_velocities()[idx]}

--- a/include/md/system/particle.hpp
+++ b/include/md/system/particle.hpp
@@ -27,6 +27,7 @@ namespace md
         md::index index;
 
         md::scalar& mass;
+        md::scalar& friction;
         md::scalar& mobility;
         md::point& position;
         md::vector& velocity;

--- a/tests/simulation/test_langevin_dynamics.cc
+++ b/tests/simulation/test_langevin_dynamics.cc
@@ -1,0 +1,116 @@
+#include <md/basic_types.hpp>
+#include <md/forcefield.hpp>
+#include <md/system.hpp>
+
+#include <md/simulation/langevin_dynamics.hpp>
+
+#include <catch.hpp>
+
+
+TEST_CASE("langevin_dynamics_config - defaults to sane configuration")
+{
+    md::langevin_dynamics_config config;
+
+    CHECK(config.temperature == 1);
+    CHECK(config.timestep == 1);
+    CHECK(config.steps == 1);
+    CHECK(config.seed == 0);
+    CHECK(!config.callback);
+}
+
+TEST_CASE("simulate_langevin_dynamics - callback step is 1-based")
+{
+    md::system system;
+    system.add_particle();
+
+    std::vector<md::step> actual_steps;
+    std::vector<md::step> expected_steps = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+    md::langevin_dynamics_config config;
+    config.steps = 10;
+    config.callback = [&](md::step step) { actual_steps.push_back(step); };
+
+    md::simulate_langevin_dynamics(system, config);
+
+    CHECK(actual_steps == expected_steps);
+}
+
+TEST_CASE("simulate_langevin_dynamics - modifies particle velocity")
+{
+    md::system system;
+    system.add_particle();
+
+    md::langevin_dynamics_config config;
+    config.steps = 1000;
+    md::simulate_langevin_dynamics(system, config);
+
+    md::vector const velocity = system.view_velocities()[0];
+    CHECK(velocity.norm() > 0);
+}
+
+TEST_CASE("simulate_langevin_dynamics - produces equipartition")
+{
+    // Simulate athermal dynamics of single particle in a harmonic well. We
+    // sample kinetic/potential energy and test equipartition property.
+
+    md::system system;
+    {
+        md::particle_ref part = system.add_particle();
+        part.mass = 1.23;
+        part.friction = 3.21e4;
+    }
+
+    class harmonic_forcefield : public md::forcefield
+    {
+    public:
+        explicit
+        harmonic_forcefield(md::scalar spring_constant)
+            : spring_constant_{spring_constant}
+        {
+        }
+
+        md::scalar
+        compute_energy(md::system const& system) override
+        {
+            md::array_view<md::point const> positions = system.view_positions();
+            md::point const pos = positions[0];
+            return 0.5 * spring_constant_ * pos.vector().squared_norm();
+        }
+
+        void
+        compute_force(md::system const& system, md::array_view<md::vector> forces) override
+        {
+            md::array_view<md::point const> positions = system.view_positions();
+            md::point const pos = positions[0];
+            md::vector const force = -spring_constant_ * pos.vector();
+            forces[0] += force;
+        }
+
+    private:
+        md::scalar spring_constant_;
+    };
+
+    system.add_forcefield(harmonic_forcefield(7.89));
+
+    md::langevin_dynamics_config config;
+    config.temperature = 1.11;
+    config.timestep = 0.01;
+    config.steps = 100000;
+    config.seed = 2;
+
+    md::scalar mean_kinetic_energy = 0;
+    md::scalar mean_potential_energy = 0;
+    config.callback = [&](md::step) {
+        mean_kinetic_energy += system.compute_kinetic_energy();
+        mean_potential_energy += system.compute_potential_energy();
+    };
+
+    md::simulate_langevin_dynamics(system, config);
+
+    mean_kinetic_energy /= md::scalar(config.steps);
+    mean_potential_energy /= md::scalar(config.steps);
+
+    // The equipartition theorem
+    CHECK(mean_kinetic_energy == Approx(1.5 * config.temperature).epsilon(0.1));
+    CHECK(mean_potential_energy == Approx(1.5 * config.temperature).epsilon(0.1));
+}

--- a/tests/test_system.cc
+++ b/tests/test_system.cc
@@ -5,8 +5,6 @@
 #include <catch.hpp>
 
 
-
-
 TEST_CASE("system::particle_count - returns zero on default state")
 {
     md::system system;
@@ -59,13 +57,14 @@ TEST_CASE("system::add_particle - can set basic attributes")
 
     md::basic_particle_data data;
     data.mass = 1.23;
+    data.friction = 4.54;
     data.mobility = 3.21;
     data.position = {4, 5, 6};
     data.velocity = {7, 8, 9};
     system.add_particle(data);
 
     CHECK(system.view_masses()[0] == data.mass);
-
+    CHECK(system.view_frictions()[0] == data.friction);
     CHECK(system.view_mobilities()[0] == data.mobility);
 
     CHECK(system.view_positions()[0].x == data.position.x);
@@ -83,12 +82,13 @@ TEST_CASE("system::add_particle - returns a particle reference")
 
     md::particle_ref part = system.add_particle();
     part.mass = 1.23;
+    part.friction = 3.21;
     part.mobility = 4.56;
     part.position = {7, 8, 9};
     part.velocity = {8, 7, 6};
 
     CHECK(system.view_masses()[0] == 1.23);
-
+    CHECK(system.view_frictions()[0] == 3.21);
     CHECK(system.view_mobilities()[0] == 4.56);
 
     CHECK(system.view_positions()[0].x == 7);
@@ -136,6 +136,35 @@ TEST_CASE("system::view_masses - returns mass attribute")
 
         md::array_view<md::scalar const> expected = const_system.view(md::mass_attribute);
         md::array_view<md::scalar const> actual = const_system.view_masses();
+
+        CHECK(actual.data() == expected.data());
+        CHECK(actual.size() == expected.size());
+    }
+}
+
+TEST_CASE("system::view_frictions - returns friction attribute")
+{
+    md::system system;
+
+    system.add_particle();
+    system.add_particle();
+    system.add_particle();
+
+    SECTION("mutable view")
+    {
+        md::array_view<md::scalar> expected = system.view(md::friction_attribute);
+        md::array_view<md::scalar> actual = system.view_frictions();
+
+        CHECK(actual.data() == expected.data());
+        CHECK(actual.size() == expected.size());
+    }
+
+    SECTION("const view")
+    {
+        md::system const& const_system = system;
+
+        md::array_view<md::scalar const> expected = const_system.view(md::friction_attribute);
+        md::array_view<md::scalar const> actual = const_system.view_frictions();
 
         CHECK(actual.data() == expected.data());
         CHECK(actual.size() == expected.size());
@@ -470,6 +499,17 @@ TEST_CASE("system - has 1-valued mass_attribute by default")
 
     CHECK(masses.size() == 1);
     CHECK(masses[0] == 1);
+}
+
+TEST_CASE("system - has 1-valued friction_attribute by default")
+{
+    md::system system;
+    system.add_particle();
+
+    md::array_view<md::scalar> frictions = system.view(md::friction_attribute);
+
+    CHECK(frictions.size() == 1);
+    CHECK(frictions[0] == 1);
 }
 
 TEST_CASE("system - has 0-valued position_attribute by default")


### PR DESCRIPTION
This PR adds support for Langevin dynamics simulation. Adds new simulation function and config structure:

- `md::simulate_langevin_dynamics(system, config)`
- `md::langevin_dynamics_config`

along with new friction attribute:

- `md::friction_attribute`
- `md::system::view_frictions()`
- `md::basic_particle_data::friction`
- `md::particle_ref::friction`

The friction attribute is kind of redundant because mobility = 1 / (mass * friction). However, specifying particle mobility in Langevin dynamics simulation feels strange. There might be a better design, but let us provide both friction and mobility attributes for now.